### PR TITLE
Add writing index page and update homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,44 +65,8 @@
 	<p>We are fiduciaries first, operators second. We operate validators and infrastructure across major networks--for ourselves and some of the largest financial institutions and funds. We provide liquidity for new ecosystems. We connect founders to institutions that will actually use their products.</p>
 	<p><strong>Complex situations:</strong></p>
 	<p>We buy distressed technology and infrastructure companies, sometimes from bankruptcy. We help founders navigate difficult exits and build new ventures from complex situations. The messier the situation, the more likely we can help.</p>
-	<p><strong>Writing:</strong></p>
-	<p>We share our analysis with partners quarterly and selectively share our perspectives on infrastructure, markets, and the projects we're involved in.</p>
-        <ul>
-                <li><a href="./writing/tunnels-and-bridges-oh-my.html">Tunnels and Bridges, oh my</a></li>
-                <li><a href="./writing/defi-101-some-basic-primitives.html">DeFi 101: Some basic primitives, where they came from (and why it matters)</a></li>
-                <li><a href="./writing/on-homeschooling.html">On Homeschooling</a></li>
-                <li><a href="./writing/what-bankers-wont-tell-you.html">What Bankers Won’t Tell You: 4 Secrets about Money Crypto Needs to Know</a></li>
-                <li><a href="./writing/the-market-vs-the-frontier.html">The Market Vs. The Frontier</a></li>
-                <li><a href="./writing/5-unanswered-questions-about-vc-deal-flow.html">5 Unanswered Questions About VC Deal Flow</a></li>
-                <li><a href="./writing/the-conservation-of-centralization.html">The Conservation Of Centralization</a></li>
-                <li><a href="./writing/common-rules-for-uncommon-people.html">Common Rules For Uncommon People</a></li>
-                <li><a href="./writing/the-dark-side-of-data-confessions-of-a-former-data-hitman.html">The Dark Side of Data (Confessions of a Former Data Hitman)</a></li>
-                <li><a href="./writing/the-ghost-ships-of-crypto.html">The Ghost Ships Of Crypto</a></li>
-                <li><a href="./writing/what-crypto-investors-and-warren-buffett-can-learn-from-vc.html">What Crypto Investors (and Warren Buffett) Can Learn From VC</a></li>
-                <li><a href="./writing/the-next-tenure-track.html">The Next Tenure Track</a></li>
-                <li><a href="./writing/the-definition-of-a-good-deal-and-how-they-mess-with-investors.html">The Definition of a ‘Good’ Deal (and How They Mess With Investors)</a></li>
-                <li><a href="./writing/10-predictions-for-the-next-5-years-of-crypto.html">10 Predictions For The Next 5 Years Of Crypto</a></li>
-                <li><a href="./writing/an-investor-s-guide-to-the-four-kinds-of-icos.html">An Investor’s Guide To The Four Kinds of ICOs</a></li>
-                <li><a href="./writing/the-seed-stage-is-now-the-seed-gradient.html">The ‘Seed Stage’ is Now The ‘Seed Gradient’</a></li>
-                <li><a href="./writing/forget-church-and-state-the-coming-separation-of-money-banks.html">Forget Church and State: The Coming Separation of Money & Banks</a></li>
-                <li><a href="./writing/5-things-ray-dalio-hasn-t-learned-about-crypto-yet.html">5 Things Ray Dalio Hasn't Learned About Crypto Yet</a></li>
-                <li><a href="./writing/poor-richards-guide-cryptocurrency.html">Poor Richard’s Guide to Cryptocurrency</a></li>
-                <li><a href="./writing/controversial-thing-for-vcs.html">A Controversial Thing for VCs to Say</a></li>
-                <li><a href="./writing/outgrowing-our-internet.html">Outgrowing Our Internet: Caught Between the Intranet and the Decentralized Web</a></li>
-                <li><a href="./writing/packaging-your-seed-round.html">Packaging your Seed Round</a></li>
-                <li><a href="./writing/21-things-young-founder.html">21 Things I Wish Someone Told Me as a Young Founder</a></li>
-                <li><a href="./writing/why-i-m-joining-founder-collective.html">Why I’m Joining Founder Collective</a></li>
-                <li><a href="./writing/what-comes-after-saas.html">What Comes After SaaS?</a></li>
-                <li><a href="./writing/5-challenges-crypto-projects-face-and-how-to-fix-them-with-programmable-securities.html">5 Challenges Crypto Projects Face (And How to Fix Them With Programmable Securities)</a></li>
-                <li><a href="./writing/what-s-left-to-build.html">What’s left to build?</a></li>
-                <li><a href="./writing/growth-roles-when-to-say-yes-or-no.html">Growth Roles — When to Say “Yes” or “No”?</a></li>
-                <li><a href="./writing/the-death-of-the-firm.html">The Death of the Firm</a></li>
-                <li><a href="./writing/why-marketers-should-learn-to-love-the-log-in.html">Why Marketers Should Learn To Love The Log-In</a></li>
-                <li><a href="./writing/on-growth.html">On Growth</a></li>
-                <li><a href="./writing/5-secrets-to-maximize-retail-sales-in-2016.html">5 Secrets to Maximize Retail Sales in 2016</a></li>
-                <li><a href="./writing/the-best-path-to-the-inbox-from-decision-to-delivery.html">The Best Path to the Inbox: From Decision to Delivery</a></li>
-                <li><a href="./writing/the-unbundling-of-email-deliverability-what-cmos-need-to-know.html">The Unbundling of Email Deliverability: What CMOs Need to Know</a></li>
-        </ul>
+        <p><strong>Writing:</strong></p>
+        <p>We share our analysis with partners quarterly and selectively share our perspectives on infrastructure, markets, and the projects we're involved in. <a href="./writing/">Writing →</a></p>
 	<p><strong>Contact:</strong></p>
 	<p>Forever time horizon. 10-year funds. We pick early with conviction and partner through uncertainty. We're based in Menlo Park and always looking for exceptional people who share our standards.</p>
 	<p><a href="mailto:inquires@proofgroup.com">inquires@proofgroup.com</a></p>

--- a/writing/index.html
+++ b/writing/index.html
@@ -1,0 +1,86 @@
+<html>
+<head>
+<meta name="description" content="Proof Group Writing"/>
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:site" content="@proofgp" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script data-goatcounter="https://proofgroup.goatcounter.com/count" async src="https://gc.zgo.at/count.js"></script>
+<link rel="canonical" href="http://proofgroup.xyz/writing" />
+<link rel="icon" type="image/x-icon" href="../img/favicon.ico">
+<style>
+        body {
+          line-height: 1.4;
+            font-size: 16px;
+            padding: 0 10px;
+            margin: 50px auto;
+            max-width: 650px;
+        }
+        #maincontent
+        {
+        max-width:42em;margin:15 auto;
+        }
+        #logo {
+                margin-bottom: 30px;
+        }
+        #logo img {
+                max-height: 60px;
+                width: auto;
+        }
+        a {
+                color: #0066cc;
+                text-decoration: none;
+        }
+        a:hover {
+                text-decoration: underline;
+        }
+</style>
+<title>Writing - Proof Group</title>
+</head>
+<body>
+<div id="maincontent" style="margin-top:70px">
+  <div id="logo">
+    <a href="../">
+      <img src="../img/ProofGroup-Lockup-Color.png" alt="Proof Group" />
+    </a>
+  </div>
+  <h1>Writing</h1>
+  <p>Some of our thinking on infrastructure, markets, and the projects we're involved in.</p>
+  <ul>
+                <li><a href="./tunnels-and-bridges-oh-my.html">Tunnels and Bridges, oh my</a></li>
+                <li><a href="./defi-101-some-basic-primitives.html">DeFi 101: Some basic primitives, where they came from (and why it matters)</a></li>
+                <li><a href="./on-homeschooling.html">On Homeschooling</a></li>
+                <li><a href="./what-bankers-wont-tell-you.html">What Bankers Won’t Tell You: 4 Secrets about Money Crypto Needs to Know</a></li>
+                <li><a href="./the-market-vs-the-frontier.html">The Market Vs. The Frontier</a></li>
+                <li><a href="./5-unanswered-questions-about-vc-deal-flow.html">5 Unanswered Questions About VC Deal Flow</a></li>
+                <li><a href="./the-conservation-of-centralization.html">The Conservation Of Centralization</a></li>
+                <li><a href="./common-rules-for-uncommon-people.html">Common Rules For Uncommon People</a></li>
+                <li><a href="./the-dark-side-of-data-confessions-of-a-former-data-hitman.html">The Dark Side of Data (Confessions of a Former Data Hitman)</a></li>
+                <li><a href="./the-ghost-ships-of-crypto.html">The Ghost Ships Of Crypto</a></li>
+                <li><a href="./what-crypto-investors-and-warren-buffett-can-learn-from-vc.html">What Crypto Investors (and Warren Buffett) Can Learn From VC</a></li>
+                <li><a href="./the-next-tenure-track.html">The Next Tenure Track</a></li>
+                <li><a href="./the-definition-of-a-good-deal-and-how-they-mess-with-investors.html">The Definition of a ‘Good’ Deal (and How They Mess With Investors)</a></li>
+                <li><a href="./10-predictions-for-the-next-5-years-of-crypto.html">10 Predictions For The Next 5 Years Of Crypto</a></li>
+                <li><a href="./an-investor-s-guide-to-the-four-kinds-of-icos.html">An Investor’s Guide To The Four Kinds of ICOs</a></li>
+                <li><a href="./the-seed-stage-is-now-the-seed-gradient.html">The ‘Seed Stage’ is Now The ‘Seed Gradient’</a></li>
+                <li><a href="./forget-church-and-state-the-coming-separation-of-money-banks.html">Forget Church and State: The Coming Separation of Money & Banks</a></li>
+                <li><a href="./5-things-ray-dalio-hasn-t-learned-about-crypto-yet.html">5 Things Ray Dalio Hasn't Learned About Crypto Yet</a></li>
+                <li><a href="./poor-richards-guide-cryptocurrency.html">Poor Richard’s Guide to Cryptocurrency</a></li>
+                <li><a href="./controversial-thing-for-vcs.html">A Controversial Thing for VCs to Say</a></li>
+                <li><a href="./outgrowing-our-internet.html">Outgrowing Our Internet: Caught Between the Intranet and the Decentralized Web</a></li>
+                <li><a href="./packaging-your-seed-round.html">Packaging your Seed Round</a></li>
+                <li><a href="./21-things-young-founder.html">21 Things I Wish Someone Told Me as a Young Founder</a></li>
+                <li><a href="./why-i-m-joining-founder-collective.html">Why I’m Joining Founder Collective</a></li>
+                <li><a href="./what-comes-after-saas.html">What Comes After SaaS?</a></li>
+                <li><a href="./5-challenges-crypto-projects-face-and-how-to-fix-them-with-programmable-securities.html">5 Challenges Crypto Projects Face (And How to Fix Them With Programmable Securities)</a></li>
+                <li><a href="./what-s-left-to-build.html">What’s left to build?</a></li>
+                <li><a href="./growth-roles-when-to-say-yes-or-no.html">Growth Roles — When to Say “Yes” or “No”?</a></li>
+                <li><a href="./the-death-of-the-firm.html">The Death of the Firm</a></li>
+                <li><a href="./why-marketers-should-learn-to-love-the-log-in.html">Why Marketers Should Learn To Love The Log-In</a></li>
+                <li><a href="./on-growth.html">On Growth</a></li>
+                <li><a href="./5-secrets-to-maximize-retail-sales-in-2016.html">5 Secrets to Maximize Retail Sales in 2016</a></li>
+                <li><a href="./the-best-path-to-the-inbox-from-decision-to-delivery.html">The Best Path to the Inbox: From Decision to Delivery</a></li>
+                <li><a href="./the-unbundling-of-email-deliverability-what-cmos-need-to-know.html">The Unbundling of Email Deliverability: What CMOs Need to Know</a></li>
+  </ul>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new `writing/index.html` with links to all writing pieces
- replace list of articles on home page with a link to the new writing page
- update copy for the writing section on the home page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841af731eb883289a781036ad28cc66