### PR TITLE
Remove Nine Realms and Thorchain from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,8 +56,6 @@
 		<li><a href="https://ondo.finance/">Ondo</a></li>
 		<li><a href="https://farcaster.xyz/">Farcaster</a></li>
 		<li><a href="https://www.lightspark.com/">Lightspark</a></li>
-		<li><a href="https://ninerealms.com/">Nine Realms</a></li>
-		<li><a href="https://thorchain.org/">Thorchain</a></li>
 		<li><a href="https://app.karak.network/">Karak</a></li>
 		<li><a href="https://allium.so">Allium</a></li>
 	</ul>


### PR DESCRIPTION
### Motivation
- Remove references and external links to Nine Realms and Thorchain from the Proof Group homepage to keep the partner list current.

### Description
- Deleted the `Nine Realms` and `Thorchain` list items from the partner list in `index.html`.

### Testing
- Ran `git diff --check` to ensure no whitespace or formatting errors and it succeeded.
- Parsed `index.html` with Python's standard-library `html.parser` to validate the file is well-formed and it succeeded.
- Confirmed no case-insensitive matches with `rg -n -i 'Nine Realms|Thorchain' index.html` and it returned no results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a70a577b08328ada49f95066cdcad)